### PR TITLE
speedup for doublemod and mulmod

### DIFF
--- a/src/modular_arithmetic.nim
+++ b/src/modular_arithmetic.nim
@@ -43,7 +43,7 @@ proc doublemod[T: SomeInteger](a, m: T): T {.inline.}=
   #if a >= m - a:
   #  result -= m
   #result += a
-  result = (a shl 1) - (if a >= m shr 1: m else: 0)
+  result = (a shl 1) - (if a >= (m - a): m else: 0)
 
 proc mulmod*[T: SomeInteger](a, b, m: T): T =
   ## Modular multiplication
@@ -56,7 +56,7 @@ proc mulmod*[T: SomeInteger](a, b, m: T): T =
     if b_m.isOdd:
       result = addmod(result, a_m, m)
     #a_m = doublemod(a_m, m)
-    a_m = (a_m shl 1) - (if a_m >= m shr 1: m else: 0)
+    a_m = (a_m shl 1) - (if a_m >= (m - a): m else: 0)
     b_m = b_m shr 1
 
 proc expmod*[T: SomeInteger](base, exponent, m: T): T =

--- a/src/modular_arithmetic.nim
+++ b/src/modular_arithmetic.nim
@@ -39,10 +39,11 @@ proc submod*[T: SomeInteger](a, b, m: T): T =
 
 proc doublemod[T: SomeInteger](a, m: T): T {.inline.}=
   ## double a modulo m. assume a < m
-  result = a
-  if a >= m - a:
-    result -= m
-  result += a
+  #result = a
+  #if a >= m - a:
+  #  result -= m
+  #result += a
+  result = (a shl 1) - (if a >= m shr 1: m else: 0)
 
 proc mulmod*[T: SomeInteger](a, b, m: T): T =
   ## Modular multiplication
@@ -54,7 +55,8 @@ proc mulmod*[T: SomeInteger](a, b, m: T): T =
   while b_m > 0.T:
     if b_m.isOdd:
       result = addmod(result, a_m, m)
-    a_m = doublemod(a_m, m)
+    #a_m = doublemod(a_m, m)
+    a_m = (a_m shl 1) - (if a_m >= m shr 1: m else: 0)
     b_m = b_m shr 1
 
 proc expmod*[T: SomeInteger](base, exponent, m: T): T =


### PR DESCRIPTION
In lieu of Nim not currently having a fast BigInt std library I've been looking at your various repos.  I'm translating my Miller-Rabin primality test from Ruby to Nim and want it to be deterministic over (for now) at least 64-bits. Your ``doublemod`` can be made a one-liner (and you can eliminate it),  by inserting the one-lner directly into ``mulmod``. This significantly sped up my code. I believe ``doublemod`` is a private to this file, so removing it shouldn't affect anything else. My benchmarks establish a significant speedup inserting the one-liner directly into ``mulmod``.  I thought it should be inlined, as if you were writing it like that, but there is a definite speed penalty on my system (using Nim 0.19.4, gcc 4.9.2, Linux 64-bit laptop, I7 cpu). I don't know if I need to compile with certain directives on. I'm just doing: ``nim c filename.nim`` or  ``nim c -d:release filename.nim``.  Get the same file size and performance.